### PR TITLE
🐛 : バリデーションエラー→登録→バリデーション成功で正常に値が送れるようにする

### DIFF
--- a/lib/ui/component/form/primary_text_field.dart
+++ b/lib/ui/component/form/primary_text_field.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
-import 'package:form_builder_validators/form_builder_validators.dart';
 
 class PrimaryTextField extends StatelessWidget {
   const PrimaryTextField(

--- a/lib/view/add_memo_sceen.dart
+++ b/lib/view/add_memo_sceen.dart
@@ -39,10 +39,11 @@ class AddMemoScreenState extends ConsumerState<AddMemoScreen> {
                     labelText: "本文",
                     errorText: _memoError,
                     isMultiLineInput: true,
-                    validator: FormBuilderValidators.compose(
-                      [FormBuilderValidators.required()],
-                    ),
-                    onChanged: (_) => _onChanged(),
+                    validator: FormBuilderValidators.compose([
+                      FormBuilderValidators.required(
+                        errorText: '最低1文字は入力が必要です',
+                      )
+                    ]),
                   ),
                 ),
                 PrimaryButton(
@@ -87,20 +88,10 @@ class AddMemoScreenState extends ConsumerState<AddMemoScreen> {
     );
   }
 
-  void _onChanged() {
-    _formKey.currentState?.save();
-    print('test');
-  }
-
   Future<void> _onPressed() async {
     setState(() => _memoError = null);
 
-    print(_formKey.currentState!.value["memo"]);
-    // print(_formKey.currentState!.validate());
-
-    // FIXME: 未入力→入力で登録をしてもバリデーションに引っかかる
-    if (!_formKey.currentState!.validate()) {
-      setState(() => _memoError = '最低1文字は入力が必要です');
+    if (!_formKey.currentState!.saveAndValidate()) {
       return;
     }
 
@@ -110,8 +101,6 @@ class AddMemoScreenState extends ConsumerState<AddMemoScreen> {
     ref
         .watch(memoContentsProvider.notifier)
         .addMemo(_formKey.currentState!.value["memo"]);
-
-    // print(_formKey.currentState!.value["memo"]);
 
     _formKey.currentState!.patchValue({'memo': ''});
   }

--- a/lib/view/add_memo_sceen.dart
+++ b/lib/view/add_memo_sceen.dart
@@ -18,7 +18,6 @@ class AddMemoScreen extends ConsumerStatefulWidget {
 
 class AddMemoScreenState extends ConsumerState<AddMemoScreen> {
   final _formKey = GlobalKey<FormBuilderState>();
-  String? _memoError;
 
   @override
   Widget build(BuildContext context) {
@@ -37,7 +36,6 @@ class AddMemoScreenState extends ConsumerState<AddMemoScreen> {
                   child: PrimaryTextField(
                     name: "memo",
                     labelText: "本文",
-                    errorText: _memoError,
                     isMultiLineInput: true,
                     validator: FormBuilderValidators.compose([
                       FormBuilderValidators.required(
@@ -89,8 +87,6 @@ class AddMemoScreenState extends ConsumerState<AddMemoScreen> {
   }
 
   Future<void> _onPressed() async {
-    setState(() => _memoError = null);
-
     if (!_formKey.currentState!.saveAndValidate()) {
       return;
     }


### PR DESCRIPTION
`FormBuilderValidators`を指定してる方でエラーテキストを登録するように修正
errorTextプロパティは不要になったので指定しない